### PR TITLE
Hack to hide notifications while in Zoom meetings

### DIFF
--- a/zoom/config.json
+++ b/zoom/config.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Zoom",
         "description": "Skip breaks while in Zoom meetings",
-        "version": "0.0.1"
+        "version": "0.1"
     },
     "dependencies": {
         "python_modules": [],

--- a/zoom/config.json
+++ b/zoom/config.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Zoom",
         "description": "Skip breaks while in Zoom meetings",
-        "version": "0.1"
+        "version": "0.2"
     },
     "dependencies": {
         "python_modules": [],

--- a/zoom/plugin.py
+++ b/zoom/plugin.py
@@ -13,8 +13,8 @@
 
 """Zoom plugin skips breaks while in zoom meetings."""
 
-import ast
 import logging
+import re
 import subprocess
 
 
@@ -25,11 +25,11 @@ def in_zoom_meeting():
     for name in ['Zoom Meeting', 'as_toolbar']:
         try:
             stdout = subprocess.check_output(
-                ['xprop', '-name', name, 'WM_CLASS'], encoding='utf-8')
+                ['xprop', '-name', name, 'WM_CLASS'], encoding='utf-8').rstrip()
         except subprocess.CalledProcessError:
             continue
         logging.debug('Found a window named {!r}, {!r}'.format(name, stdout))
-        if stdout == 'WM_CLASS(STRING) = "zoom", "zoom"\n':
+        if re.match(r'^WM_CLASS\(STRING\) = "\s*zoom\s*"', stdout, flags=re.IGNORECASE):
             logging.debug('In a Zoom meeting')
             return True
     return False


### PR DESCRIPTION
This is definitely a hack. That's why it is all wrapped inside a `try...except` block. I understand if the PR is rejected.

A possible solution might be to provide a method to indicate the order of plugins or, even better, the order of individual plugin hooks. The simplest might be a decorator to specify dependencies:

```python
# plugin.py
from safeeyes.ordering import order

def init(...):
    ...

@order(before=['notification'])
def on_pre_break(break_obj):
    ...

@order(after=['donotdisturb'])
def on_start_break(break_obj):
    ...
```